### PR TITLE
[*] Fixed the bug when reorder the columns of the table & Adjust…

### DIFF
--- a/src/main/java/billgates/view/gui/ActionTextArea.java
+++ b/src/main/java/billgates/view/gui/ActionTextArea.java
@@ -12,7 +12,7 @@ public class ActionTextArea extends JTextArea {
 
     public static final int DEFAULT_FONT_SIZE = 14;
     public static final Font DEFAULT_FONT = new FontSettings(DEFAULT_FONT_SIZE);
-    public static final int DEFAULT_HEIGHT = ActionPanel.DEFAULT_HEIGHT / 3;
+    public static final int DEFAULT_HEIGHT = ActionPanel.DEFAULT_HEIGHT / 5 * 2;
     public static final Color DEFAULT_BACKGROUND_COLOR = new Color(230, 230, 230);
 
     public ActionTextArea(String text) {

--- a/src/main/java/billgates/view/gui/BillTable.java
+++ b/src/main/java/billgates/view/gui/BillTable.java
@@ -45,6 +45,9 @@ public class BillTable extends JTable {
 
         // Set functionality
         this.setCellSelectionEnabled(true);
+
+        // The user cannot reorder the columns of the table
+        this.getTableHeader().setReorderingAllowed(false);
     }
 
     @Override
@@ -81,8 +84,8 @@ public class BillTable extends JTable {
         List<String> statistics = new ArrayList<>();
         List<Double> values = new ArrayList<>();
         List<String> currencyValues = new ArrayList<>();
-        int valueCol = 2;
-        int currencyCol = 3;
+        int valueCol = this.getColumn("Value").getModelIndex();
+        int currencyCol = this.getColumn("Currency").getModelIndex();
 
         if (selectedColumns.length == 1) {
             int[] selectedRows = this.getSelectedRows();

--- a/src/main/java/billgates/view/gui/MainFrame.java
+++ b/src/main/java/billgates/view/gui/MainFrame.java
@@ -41,7 +41,10 @@ public class MainFrame extends JFrame {
 
         this.setDefaultCloseOperation(EXIT_ON_CLOSE);
 
-        // Set the size of the window, and the user cannot resize the window
+        // Set full screen
+        this.setExtendedState(JFrame.MAXIMIZED_BOTH);
+
+        // Set the size of the window, and the user can resize the window
         this.setSize(DEFAULT_WIDTH, DEFAULT_HEIGHT);
         this.setResizable(true);
 

--- a/src/main/java/billgates/view/gui/MainFrame.java
+++ b/src/main/java/billgates/view/gui/MainFrame.java
@@ -17,9 +17,9 @@ import java.awt.*;
 public class MainFrame extends JFrame {
 
     // window width
-    public static final int DEFAULT_WIDTH = 1200;
+    public static final int DEFAULT_WIDTH = 1250;
     // window height
-    public static final int DEFAULT_HEIGHT = 740;
+    public static final int DEFAULT_HEIGHT = 750;
     public static final Color DEFAULT_BACKGROUND_COLOR = new Color(220, 120, 150, 100);
 
     private final ActionPanel actionPanel = new ActionPanel(this);


### PR DESCRIPTION
# Main Modification

- [x] Fix the bug when the user reorders the columns of the bill table.
- [x] Adjust the size of the main window to display the full text of the table header for the splitter.
- [x] Adjust the size of the statistics text area to prevent the showing statistics exceeding the border.

# New Feature

- [x] Set full screen